### PR TITLE
データソース層実装

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ osx_image: xcode7.2
 xcode_workspace: TimeLogger.xcworkspace
 xcode_scheme: TimeLogger
 xcode_sdk: iphonesimulator
+notifications:
+  on_success: never
+  on_failure: never

--- a/TimeLogger.xcodeproj/project.pbxproj
+++ b/TimeLogger.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		292AE2FF1C363466008AB2FA /* HALTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292AE2FE1C363466008AB2FA /* HALTestCase.swift */; };
 		292AE3031C36B5FE008AB2FA /* TaskData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292AE3021C36B5FE008AB2FA /* TaskData.swift */; };
 		292AE3061C36C79C008AB2FA /* TaskDataTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292AE3051C36C79C008AB2FA /* TaskDataTest.swift */; };
+		292AE3081C37DED0008AB2FA /* TaskLogData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292AE3071C37DED0008AB2FA /* TaskLogData.swift */; };
+		292AE30A1C37E175008AB2FA /* TaskLogDataTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292AE3091C37E175008AB2FA /* TaskLogDataTest.swift */; };
 		CE1848326A4B4B25F9D59C05 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C17C5CCBC010A96385D4C67 /* Pods.framework */; };
 /* End PBXBuildFile section */
 
@@ -69,6 +71,8 @@
 		292AE2FE1C363466008AB2FA /* HALTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HALTestCase.swift; sourceTree = "<group>"; };
 		292AE3021C36B5FE008AB2FA /* TaskData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskData.swift; sourceTree = "<group>"; };
 		292AE3051C36C79C008AB2FA /* TaskDataTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskDataTest.swift; sourceTree = "<group>"; };
+		292AE3071C37DED0008AB2FA /* TaskLogData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskLogData.swift; sourceTree = "<group>"; };
+		292AE3091C37E175008AB2FA /* TaskLogDataTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskLogDataTest.swift; sourceTree = "<group>"; };
 		D0506C6B60ADA6835DED02A5 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		D29DD4EBC358B376EFA97266 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -182,6 +186,7 @@
 			isa = PBXGroup;
 			children = (
 				292AE3021C36B5FE008AB2FA /* TaskData.swift */,
+				292AE3071C37DED0008AB2FA /* TaskLogData.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -190,6 +195,7 @@
 			isa = PBXGroup;
 			children = (
 				292AE3051C36C79C008AB2FA /* TaskDataTest.swift */,
+				292AE3091C37E175008AB2FA /* TaskLogDataTest.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -398,6 +404,7 @@
 				2918C1C91C31808200C07CCE /* RootViewController.swift in Sources */,
 				2918C1CD1C31808200C07CCE /* ModelController.swift in Sources */,
 				292AE2B11C33AE05008AB2FA /* Task.swift in Sources */,
+				292AE3081C37DED0008AB2FA /* TaskLogData.swift in Sources */,
 				2918C1CB1C31808200C07CCE /* DataViewController.swift in Sources */,
 				292AE3031C36B5FE008AB2FA /* TaskData.swift in Sources */,
 				2918C1C71C31808200C07CCE /* AppDelegate.swift in Sources */,
@@ -413,6 +420,7 @@
 				292AE2BA1C33DD08008AB2FA /* TaskLogTest.swift in Sources */,
 				292AE3061C36C79C008AB2FA /* TaskDataTest.swift in Sources */,
 				292AE2B51C33CDFA008AB2FA /* TaskTest.swift in Sources */,
+				292AE30A1C37E175008AB2FA /* TaskLogDataTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TimeLogger.xcodeproj/project.pbxproj
+++ b/TimeLogger.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		292AE2FC1C356C69008AB2FA /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 292AE2FA1C356C69008AB2FA /* Realm.framework */; };
 		292AE2FD1C356C69008AB2FA /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 292AE2FB1C356C69008AB2FA /* RealmSwift.framework */; };
 		292AE2FF1C363466008AB2FA /* HALTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292AE2FE1C363466008AB2FA /* HALTestCase.swift */; };
+		292AE3031C36B5FE008AB2FA /* TaskData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292AE3021C36B5FE008AB2FA /* TaskData.swift */; };
+		292AE3061C36C79C008AB2FA /* TaskDataTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292AE3051C36C79C008AB2FA /* TaskDataTest.swift */; };
 		CE1848326A4B4B25F9D59C05 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C17C5CCBC010A96385D4C67 /* Pods.framework */; };
 /* End PBXBuildFile section */
 
@@ -65,6 +67,8 @@
 		292AE2FA1C356C69008AB2FA /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = "Pods/../build/Debug-iphoneos/Realm.framework"; sourceTree = "<group>"; };
 		292AE2FB1C356C69008AB2FA /* RealmSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealmSwift.framework; path = "Pods/../build/Debug-iphoneos/RealmSwift.framework"; sourceTree = "<group>"; };
 		292AE2FE1C363466008AB2FA /* HALTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HALTestCase.swift; sourceTree = "<group>"; };
+		292AE3021C36B5FE008AB2FA /* TaskData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskData.swift; sourceTree = "<group>"; };
+		292AE3051C36C79C008AB2FA /* TaskDataTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskDataTest.swift; sourceTree = "<group>"; };
 		D0506C6B60ADA6835DED02A5 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		D29DD4EBC358B376EFA97266 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -122,6 +126,7 @@
 		2918C1C51C31808200C07CCE /* TimeLogger */ = {
 			isa = PBXGroup;
 			children = (
+				292AE3011C36B5D1008AB2FA /* Data */,
 				292AE2AF1C33AD80008AB2FA /* Entity */,
 				2918C1C61C31808200C07CCE /* AppDelegate.swift */,
 				2918C1C81C31808200C07CCE /* RootViewController.swift */,
@@ -138,6 +143,7 @@
 		2918C1DE1C31808200C07CCE /* TimeLoggerTests */ = {
 			isa = PBXGroup;
 			children = (
+				292AE3041C36C75D008AB2FA /* Data */,
 				292AE2B31C33CDCA008AB2FA /* Entity */,
 				2918C1E11C31808200C07CCE /* Info.plist */,
 				292AE2FE1C363466008AB2FA /* HALTestCase.swift */,
@@ -170,6 +176,22 @@
 				292AE2B91C33DD08008AB2FA /* TaskLogTest.swift */,
 			);
 			path = Entity;
+			sourceTree = "<group>";
+		};
+		292AE3011C36B5D1008AB2FA /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				292AE3021C36B5FE008AB2FA /* TaskData.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		292AE3041C36C75D008AB2FA /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				292AE3051C36C79C008AB2FA /* TaskDataTest.swift */,
+			);
+			path = Data;
 			sourceTree = "<group>";
 		};
 		573689D042FB83B8480B1320 /* Frameworks */ = {
@@ -377,6 +399,7 @@
 				2918C1CD1C31808200C07CCE /* ModelController.swift in Sources */,
 				292AE2B11C33AE05008AB2FA /* Task.swift in Sources */,
 				2918C1CB1C31808200C07CCE /* DataViewController.swift in Sources */,
+				292AE3031C36B5FE008AB2FA /* TaskData.swift in Sources */,
 				2918C1C71C31808200C07CCE /* AppDelegate.swift in Sources */,
 				292AE2B71C33D815008AB2FA /* TaskLog.swift in Sources */,
 			);
@@ -388,6 +411,7 @@
 			files = (
 				292AE2FF1C363466008AB2FA /* HALTestCase.swift in Sources */,
 				292AE2BA1C33DD08008AB2FA /* TaskLogTest.swift in Sources */,
+				292AE3061C36C79C008AB2FA /* TaskDataTest.swift in Sources */,
 				292AE2B51C33CDFA008AB2FA /* TaskTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TimeLogger/Data/TaskData.swift
+++ b/TimeLogger/Data/TaskData.swift
@@ -1,0 +1,61 @@
+//
+//  TaskData.swift
+//  TimeLogger
+//
+//  Created by 信田 春満 on 2016/01/01.
+//  Copyright © 2016年 halhorn. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+class TaskData {
+    var realm : Realm?
+    
+    init() throws {
+        try self.realm = Realm()
+    }
+    
+    func create(name name : String, color : String = "#f0fff0") throws -> Task {
+        let maxId : Int = readList()?.sorted("taskId", ascending: false).first?.taskId ?? 0
+        let task = Task(value: ["taskId": maxId + 1, "name": name, "color": color, "createdAt" : getCurrentDate()])
+        try realm?.write {
+            realm?.add(task)
+        }
+        return task
+    }
+    
+    func read(taskId : Int) -> Task? {
+        let predicate = NSPredicate(format: "taskId = %d", taskId)
+        return self.realm?.objects(Task).filter(predicate).first
+    }
+    
+    func readList() -> Results<Task>? {
+        return self.realm?.objects(Task)
+    }
+    
+    func updateName(name : String, task : Task) throws -> Task {
+        try realm?.write {
+            task.name = name
+        }
+        return task
+    }
+
+    func updateColor(color : String, task : Task) throws -> Task {
+        try realm?.write {
+            task.color = color
+        }
+        return task
+    }
+
+    func delete(task : Task) throws {
+        try realm?.write {
+            realm?.delete(task)
+        }
+    }
+    
+    // for DI
+    var getCurrentDate = {
+        return NSDate()
+    }
+}

--- a/TimeLogger/Data/TaskLogData.swift
+++ b/TimeLogger/Data/TaskLogData.swift
@@ -1,0 +1,48 @@
+//
+//  TaskLogData.swift
+//  TimeLogger
+//
+//  Created by 信田 春満 on 2016/01/02.
+//  Copyright © 2016年 halhorn. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+class TaskLogData {
+    var realm : Realm?
+    
+    init() throws {
+        try self.realm = Realm()
+    }
+    
+    func create(taskId taskId: Int) throws -> TaskLog {
+        let taskLog = TaskLog(value: ["taskId": taskId, "startedAt": getCurrentDate()])
+        try realm?.write {
+            realm?.add(taskLog)
+        }
+        return taskLog
+    }
+
+    func readList() -> Results<TaskLog>? {
+        return self.realm?.objects(TaskLog)
+    }
+    
+    func end(taskLog : TaskLog) throws -> TaskLog {
+        try realm?.write {
+            taskLog.endedAt = getCurrentDate()
+        }
+        return taskLog
+    }
+    
+    func delete(taskLog : TaskLog) throws {
+        try realm?.write {
+            realm?.delete(taskLog)
+        }
+    }
+    
+    // for DI
+    var getCurrentDate = {
+        return NSDate()
+    }
+}

--- a/TimeLogger/Entity/TaskLog.swift
+++ b/TimeLogger/Entity/TaskLog.swift
@@ -13,19 +13,6 @@ class TaskLog : Object, Equatable {
     dynamic var taskId = 0
     dynamic var startedAt = NSDate(timeIntervalSince1970: 0)
     dynamic var endedAt : NSDate?
-
-    func end() {
-        self.endedAt = self.getCurrentDate()
-    }
-    
-    // DI for testing
-    var getCurrentDate = {
-        return NSDate()
-    }
-    
-    override static func ignoredProperties() -> [String] {
-        return ["getCurrentDate"]
-    }
 }
 
 func == (left : TaskLog, right: TaskLog) -> Bool {

--- a/TimeLoggerTests/Data/TaskDataTest.swift
+++ b/TimeLoggerTests/Data/TaskDataTest.swift
@@ -1,0 +1,101 @@
+//
+//  TaskDataTest.swift
+//  TimeLogger
+//
+//  Created by 信田 春満 on 2016/01/01.
+//  Copyright © 2016年 halhorn. All rights reserved.
+//
+
+import XCTest
+import RealmSwift
+@testable import TimeLogger
+
+class TaskDataTest: HALTestCase {
+    var taskData : TaskData?
+
+    override func setUp() {
+        super.setUp()
+        self.taskData = try! TaskData()
+        self.taskData?.getCurrentDate = {
+            return NSDate(timeIntervalSince1970: 1)
+        }
+    }
+    
+    override func tearDown() {
+        let realm = try! Realm()
+        try! realm.write {
+            realm.deleteAll()
+        }
+        super.tearDown()
+    }
+    
+    func testCreate() {
+        let task1 = try! self.taskData!.create(name: "hoge")
+        XCTAssertEqual(task1.taskId, 1)
+        XCTAssertEqual(task1.name, "hoge")
+        XCTAssertEqual(task1.color, "#f0fff0")
+        XCTAssertEqual(task1.createdAt, NSDate(timeIntervalSince1970: 1))
+        
+        let task2 = try! self.taskData!.create(name: "fuga", color: "#000000")
+        XCTAssertEqual(task2.taskId, 2)
+        XCTAssertEqual(task2.name, "fuga")
+        XCTAssertEqual(task2.color, "#000000")
+        XCTAssertEqual(task2.createdAt, NSDate(timeIntervalSince1970: 1))
+        
+        let stored1 = self.taskData!.read(1)!
+        XCTAssertEqual(stored1.taskId, 1)
+        XCTAssertEqual(stored1.name, "hoge")
+        XCTAssertEqual(stored1.color, "#f0fff0")
+        XCTAssertEqual(stored1.createdAt, NSDate(timeIntervalSince1970: 1))
+        
+        let stored2 = self.taskData!.read(2)!
+        XCTAssertEqual(stored2.taskId, 2)
+        XCTAssertEqual(stored2.name, "fuga")
+        XCTAssertEqual(stored2.color, "#000000")
+        XCTAssertEqual(stored2.createdAt, NSDate(timeIntervalSince1970: 1))
+    }
+    
+    func testReadList() {
+        let task1 = try! self.taskData!.create(name: "hoge")
+        
+        let results = self.taskData?.readList()
+        XCTAssertEqual(results?.count, 1)
+        XCTAssertEqual(results?[0], task1)
+        
+        let task2 = try! self.taskData!.create(name: "fuga", color: "#000000")
+        XCTAssertEqual(results?.count, 2)
+        XCTAssertEqual(results?[0], task1)
+        XCTAssertEqual(results?[1], task2)
+    }
+    
+    func testUpdateName() {
+        let task1 = try! self.taskData!.create(name: "hoge")
+        let task2 = try! self.taskData!.create(name: "fuga", color: "#000000")
+        
+        try! self.taskData!.updateName("moge", task: task1)
+        XCTAssertEqual(task1.name, "moge")
+        XCTAssertEqual(task2.name, "fuga")
+        XCTAssertEqual(self.taskData!.read(1)!.name, "moge")
+        XCTAssertEqual(self.taskData!.read(2)!.name, "fuga")
+    }
+    
+    func testUpdateColor() {
+        let task1 = try! self.taskData!.create(name: "hoge", color: "#111111")
+        let task2 = try! self.taskData!.create(name: "fuga", color: "#000000")
+        
+        try! self.taskData!.updateColor("#222222", task: task1)
+        XCTAssertEqual(task1.color, "#222222")
+        XCTAssertEqual(task2.color, "#000000")
+        XCTAssertEqual(self.taskData!.read(1)!.color, "#222222")
+        XCTAssertEqual(self.taskData!.read(2)!.color, "#000000")
+    }
+    
+    func testDelete() {
+        let task1 = try! self.taskData!.create(name: "hoge", color: "#111111")
+        try! self.taskData!.create(name: "fuga", color: "#000000")
+        
+        try! self.taskData!.delete(task1)
+        XCTAssertNil(self.taskData!.read(1))
+        XCTAssertNotNil(self.taskData!.read(2))
+    }
+}

--- a/TimeLoggerTests/Data/TaskLogDataTest.swift
+++ b/TimeLoggerTests/Data/TaskLogDataTest.swift
@@ -1,0 +1,68 @@
+//
+//  TaskLogDataTest.swift
+//  TimeLogger
+//
+//  Created by 信田 春満 on 2016/01/02.
+//  Copyright © 2016年 halhorn. All rights reserved.
+//
+
+import XCTest
+import RealmSwift
+@testable import TimeLogger
+
+class TaskLogDataTest: HALTestCase {
+    var taskLogData : TaskLogData?
+    var time : NSTimeInterval = 1
+
+    override func setUp() {
+        super.setUp()
+        taskLogData = try! TaskLogData()
+        taskLogData?.getCurrentDate = {
+            return NSDate(timeIntervalSince1970: self.time)
+        }
+    }
+    
+    override func tearDown() {
+        let realm = try! Realm()
+        try! realm.write {
+            realm.deleteAll()
+        }
+        super.tearDown()
+    }
+
+    func testCreate() {
+        self.time = 1
+        let log1 = try! self.taskLogData!.create(taskId: 1)
+        self.time = 10
+        let log2 = try! self.taskLogData!.create(taskId: 2)
+        
+        let results = self.taskLogData!.readList()
+        XCTAssertEqual(results![0], log1)
+        XCTAssertEqual(results![1], log2)
+    }
+    
+    func testEnd() {
+        self.time = 1
+        let log1 = try! self.taskLogData!.create(taskId: 1)
+        self.time = 10
+        try! self.taskLogData!.end(log1)
+        try! self.taskLogData!.create(taskId: 2)
+        
+        let results = self.taskLogData?.readList()
+        XCTAssertEqual(results![0].endedAt, NSDate(timeIntervalSince1970: 10))
+        XCTAssertNil(results![1].endedAt)
+    }
+    
+    func testDelete() {
+        self.time = 1
+        let log1 = try! self.taskLogData!.create(taskId: 1)
+        self.time = 10
+        let log2 = try! self.taskLogData!.create(taskId: 2)
+
+        let results = self.taskLogData?.readList()
+        XCTAssertEqual(results![0], log1)
+        XCTAssertEqual(results![1], log2)
+        try! self.taskLogData!.delete(log1)
+        XCTAssertEqual(results![0], log2)
+    }
+}

--- a/TimeLoggerTests/Entity/TaskLogTest.swift
+++ b/TimeLoggerTests/Entity/TaskLogTest.swift
@@ -24,9 +24,6 @@ class TaskLogTest: HALTestCase {
         
         var notificationCalled = false;
         let taskLog = TaskLog(value: ["taskId": 1, "startedAt": NSDate(timeIntervalSince1970: 1)])
-        taskLog.getCurrentDate = {
-            return NSDate(timeIntervalSince1970: 10)
-        }
         
         let realm2 = try! Realm();
         token = realm2.addNotificationBlock { (notification, realm) -> Void in
@@ -35,7 +32,7 @@ class TaskLogTest: HALTestCase {
         let realm = try! Realm();
         try! realm.write {
             realm.add(taskLog)
-            taskLog.end()
+            taskLog.endedAt = NSDate(timeIntervalSince1970: 10)
         }
         XCTAssertEqual(realm.objects(TaskLog).first, taskLog)
         XCTAssertEqual(realm.objects(TaskLog).first!.endedAt, NSDate(timeIntervalSince1970: 10))


### PR DESCRIPTION
Realm を介して DB アクセスを行うレイヤー。
Entity の CRUD インターフェースを提供する。
Entity 自体が Realm 前提の実装になっているため、 Entity 自体にこの機能をもたせても良い気がしたが、今回はデータソースを分離した。
